### PR TITLE
Literal test - replace anonymous object namednode with factory method

### DIFF
--- a/test/literal.js
+++ b/test/literal.js
@@ -66,7 +66,7 @@ function runTests (DataFactory) {
 
     it('should create an object with a datatype property that contains the given NamedNode', function () {
       var string = 'example'
-      var datatype = {termType: 'NamedNode', value: 'http://example.org'}
+      var datatype = DataFactory.namedNode('http://example.org')
       var term = DataFactory.literal(string, datatype)
 
       assert.equal(term.datatype.termType, 'NamedNode')


### PR DESCRIPTION
Replace "fake" (anonymous object) NamedNode datatype instance with a DataFactory method.
